### PR TITLE
bug(csharp/src/Drivers/Apache/Spark): correct SparkConnection.GetTableSchema to use native column type

### DIFF
--- a/csharp/src/Drivers/Apache/Spark/SparkConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkConnection.cs
@@ -58,11 +58,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
             { "spark.thriftserver.arrowBasedRowSet.timestampAsString", "false" }
         };
 
-        private static Dictionary<ColumnTypeId, IArrowType> s_ColumnTypeToArrowTypeMap;
-
-        static SparkConnection()
-        {
-            s_ColumnTypeToArrowTypeMap = new() {
+        private static readonly IReadOnlyDictionary<ColumnTypeId, IArrowType> s_columnTypeToArrowTypeMap = new Dictionary<ColumnTypeId, IArrowType>() {
                 { ColumnTypeId.BOOLEAN_TYPE, BooleanType.Default },
                 { ColumnTypeId.TINYINT_TYPE, Int8Type.Default },
                 { ColumnTypeId.SMALLINT_TYPE, Int16Type.Default },
@@ -80,9 +76,8 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
                 { ColumnTypeId.DATE_TYPE, Date32Type.Default },
                 { ColumnTypeId.CHAR_TYPE, StringType.Default },
             };
-        }
 
-        public enum ColumnTypeId
+        private enum ColumnTypeId
         {
             BOOLEAN_TYPE = 16,
             TINYINT_TYPE = -6,
@@ -516,7 +511,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
 
         private static IArrowType GetArrowType(ColumnTypeId columnTypeId)
         {
-            if (!s_ColumnTypeToArrowTypeMap.TryGetValue(columnTypeId, out IArrowType arrowType))
+            if (!s_columnTypeToArrowTypeMap.TryGetValue(columnTypeId, out IArrowType arrowType))
             {
                 throw new NotImplementedException($"Unsupported column type id: {columnTypeId}");
             }

--- a/csharp/test/Drivers/Apache/Spark/Resources/SparkData.sql
+++ b/csharp/test/Drivers/Apache/Spark/Resources/SparkData.sql
@@ -28,13 +28,20 @@ CREATE TABLE IF NOT EXISTS {ADBC_CATALOG}.{ADBC_DATASET}.{ADBC_TABLE} (
   name STRING,
   data BINARY,
   date DATE,
-  timestamp TIMESTAMP_NTZ,
-  timestamp_local TIMESTAMP_LTZ,
+  timestamp TIMESTAMP,
+  timestamp_ntz TIMESTAMP_NTZ,
+  timestamp_ltz TIMESTAMP_LTZ,
   numbers ARRAY<LONG>,
   person STRUCT <
     name STRING,
     age LONG
-  >
+  >,
+  map MAP <
+    INT,
+    STRING
+  >,
+  varchar VARCHAR(255),
+  char CHAR(10)
 );
 
 INSERT INTO {ADBC_CATALOG}.{ADBC_DATASET}.{ADBC_TABLE} (
@@ -42,9 +49,12 @@ INSERT INTO {ADBC_CATALOG}.{ADBC_DATASET}.{ADBC_TABLE} (
     byte, short, integer, float, number, decimal,
     is_active,
     name, data,
-    date, timestamp, timestamp_local,
+    date, timestamp, timestamp_ntz, timestamp_ltz,
     numbers,
-    person
+    person,
+    map,
+    varchar,
+    char
 )
 VALUES (
     1,
@@ -53,9 +63,12 @@ VALUES (
     'John Doe',
     -- hex-encoded value `abc123`
     X'616263313233',
-    '2023-09-08', '2023-09-08 12:34:56', '2023-09-08 12:34:56+00:00',
+    '2023-09-08', '2023-09-08 12:34:56', '2023-09-08 12:34:56', '2023-09-08 12:34:56+00:00',
     ARRAY(1, 2, 3),
-    STRUCT('John Doe', 30)
+    STRUCT('John Doe', 30),
+    MAP(1, 'John Doe'),
+    'John Doe',
+    'John Doe'
 );
 
 INSERT INTO {ADBC_CATALOG}.{ADBC_DATASET}.{ADBC_TABLE} (
@@ -63,9 +76,12 @@ INSERT INTO {ADBC_CATALOG}.{ADBC_DATASET}.{ADBC_TABLE} (
     byte, short, integer, float, number, decimal,
     is_active,
     name, data,
-    date, timestamp, timestamp_local,
+    date, timestamp, timestamp_ntz, timestamp_ltz,
     numbers,
-    person
+    person,
+    map,
+    varchar,
+    char
 )
 VALUES (
     2,
@@ -74,9 +90,12 @@ VALUES (
     'Jane Doe',
     -- hex-encoded `def456`
     X'646566343536',
-    '2023-09-09', '2023-09-09 13:45:57', '2023-09-09 13:45:57+00:00',
+    '2023-09-09', '2023-09-09 13:45:57', '2023-09-09 13:45:57', '2023-09-09 13:45:57+00:00',
     ARRAY(4, 5, 6),
-    STRUCT('Jane Doe', 40)
+    STRUCT('Jane Doe', 40),
+    MAP(1, 'John Doe'),
+    'Jane Doe',
+    'Jane Doe'
 );
 
 INSERT INTO {ADBC_CATALOG}.{ADBC_DATASET}.{ADBC_TABLE} (
@@ -84,9 +103,12 @@ INSERT INTO {ADBC_CATALOG}.{ADBC_DATASET}.{ADBC_TABLE} (
     byte, short, integer, float, number, decimal,
     is_active,
     name, data,
-    date, timestamp, timestamp_local,
+    date, timestamp, timestamp_ntz, timestamp_ltz,
     numbers,
-    person
+    person,
+    map,
+    varchar,
+    char
 )
 VALUES (
     3,
@@ -95,9 +117,12 @@ VALUES (
     'Jack Doe',
     -- hex-encoded `def456`
     X'646566343536',
-    '1556-01-02', '1970-01-01 00:00:00', '9999-12-31 23:59:59+00:00',
+    '1556-01-02', '1970-01-01 00:00:00', '1970-01-01 00:00:00', '9999-12-31 23:59:59+00:00',
     ARRAY(7, 8, 9),
-    STRUCT('Jack Doe', 50)
+    STRUCT('Jack Doe', 50),
+    MAP(1, 'John Doe'),
+    'Jack Doe',
+    'Jack Doe'
 );
 
 UPDATE {ADBC_CATALOG}.{ADBC_DATASET}.{ADBC_TABLE}


### PR DESCRIPTION
Uses "native" column type ids - which are based on JDBC's Types constants.
Update SparkData.sql to include fully covered table data types definitions.